### PR TITLE
Specify versions of version-sensitive dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-tensorflow
+tensorflow==2.2
 numpy
-tensorflow-addons
+tensorflow-addons==0.10.0
 gin-config
 tqdm
 imageio
 gdown
+opencv-python==4.5.3.56
+jupyterlab


### PR DESCRIPTION
I was not able to reproduce the notebook with the dependencies as-is. With specific versions for tensorflow, tensorflow_addons and opencv, everything worked out of the box.